### PR TITLE
Feature/state

### DIFF
--- a/lib/cocoon.dart
+++ b/lib/cocoon.dart
@@ -232,7 +232,7 @@ class Cocoon extends StatelessWidget {
         json['home'],
         stateKey: stateKey,
       ),
-      title: json['title'],
+      title: _valueFromState(json, 'title', stateKey),
       theme: _buildTheme(context, json['theme'], stateKey: stateKey),
       debugShowCheckedModeBanner: json["debug"] != null ? json["debug"] : false,
     );


### PR DESCRIPTION
## Description
Implemented support for stateful widgets
- Defining a widget's 'state' wraps that widget in a stateful widget
- State values defined as key, value
- Child widgets inherit state from their closest parent
- 'state_change' tap function can change values in the widget's state
- Widgets defining 'state_value' type object with a key take their value from the state
- Included state support for Icon, MaterialApp, ThemeData, SizedBox, Card, ListTile, FloatingActionButton, RaisedButton, Text

### JSON example

[app.txt](https://github.com/netsells/cocoon/files/2787514/app.txt)
