### PR TITLE
Add support for triggering Firebase Cloud Functions with buttons

### DIFF
--- a/docs/widgets/fab.md
+++ b/docs/widgets/fab.md
@@ -1,4 +1,4 @@
-# Floating Action Button
+# Floating Action Button
 
 A Material Design Floating Action Button, which can display an icon and an optional label. Tapping the FAB will navigate to a different screen.
 
@@ -9,7 +9,8 @@ A Material Design Floating Action Button, which can display an icon and an optio
     "icon": "alarm",
     "destination": {
         "type": "scaffold"
-    }
+    },
+    "cloud_function": "my_function"
 }
 ```
 
@@ -18,6 +19,8 @@ The `label` property is optional.
 The `destination` property is required and must be a [`scaffold`](scaffold.md).
 
 The `icon` property must be the name of a Material Design or FontAwesome icon.
+
+The `cloud_function` property is optional, and must be the name of the Firebase Cloud Function to call when the button is pressed. The Cloud Function must be defined as a callable function in your app's Firebase project, as detailed [here](https://firebase.google.com/docs/functions/callable). After the function is successfully executed, if there is a `destination` property the app will navigate to that destination.
 
 ## See Also
 

--- a/docs/widgets/outline_button.md
+++ b/docs/widgets/outline_button.md
@@ -11,13 +11,16 @@ A Material Design Outlined Button.
     },
     "state_change": {
         "text": "Alarm created"
-    }
+    },
+    "cloud_function": "my_function"
 }
 ```
 
 One of `destination` and `state_change` is required.
 The `destination` property must be a [`scaffold`](scaffold.md).
 The `state_change` property must be a [`state_change`](../state/state_change.md)
+
+The `cloud_function` property is optional, and must be the name of the Firebase Cloud Function to call when the button is pressed. The Cloud Function must be defined as a callable function in your app's Firebase project, as detailed [here](https://firebase.google.com/docs/functions/callable). After the function is successfully executed, if there is a `destination` property the app will navigate to that destination.
 
 
 ## See Also

--- a/docs/widgets/raised_button.md
+++ b/docs/widgets/raised_button.md
@@ -11,13 +11,16 @@ A Material Design Contained Button with text.
     },
     "state_change": {
         "text": "Alarm created"
-    }
+    },
+    "cloud_function": "my_function"
 }
 ```
 
 One of `destination` and `state_change` is required.
 The `destination` property must be a [`scaffold`](scaffold.md).
 The `state_change` property must be a [`state_change`](../state/state_change.md)
+
+The `cloud_function` property is optional, and must be the name of the Firebase Cloud Function to call when the button is pressed. The Cloud Function must be defined as a callable function in your app's Firebase project, as detailed [here](https://firebase.google.com/docs/functions/callable). After the function is successfully executed, if there is a `destination` property the app will navigate to that destination.
 
 
 ## See Also

--- a/docs/widgets/text_button.md
+++ b/docs/widgets/text_button.md
@@ -11,7 +11,8 @@ A Material Design Text Button.
     },
     "state_change": {
         "text": "Alarm created"
-    }
+    },
+    "cloud_function": "my_function"
 }
 ```
 
@@ -19,6 +20,7 @@ One of `destination` and `state_change` is required.
 The `destination` property must be a [`scaffold`](scaffold.md).
 The `state_change` property must be a [`state_change`](../state/state_change.md)
 
+The `cloud_function` property is optional, and must be the name of the Firebase Cloud Function to call when the button is pressed. The Cloud Function must be defined as a callable function in your app's Firebase project, as detailed [here](https://firebase.google.com/docs/functions/callable). After the function is successfully executed, if there is a `destination` property the app will navigate to that destination.
 
 ## See Also
 

--- a/lib/cocoon.dart
+++ b/lib/cocoon.dart
@@ -738,12 +738,16 @@ class Cocoon extends StatelessWidget {
   ) {
     if (json.containsKey('cloud_function')) {
       return () async {
-        await CloudFunctions.instance
-            .getHttpsCallable(functionName: json['cloud_function'])
-            .call();
-        if (json.containsKey('destination')) {
-          Navigator.of(context).push(MaterialPageRoute(
-              builder: (context) => Cocoon(json['destination'])));
+        try {
+          await CloudFunctions.instance
+              .getHttpsCallable(functionName: json['cloud_function'])
+              .call();
+          if (json.containsKey('destination')) {
+            Navigator.of(context).push(MaterialPageRoute(
+                builder: (context) => Cocoon(json['destination'])));
+          }
+        } catch (e) {
+          Scaffold.of(context).showSnackBar(SnackBar(content: Text(e.message)));
         }
       };
     } else if (json.containsKey('destination')) {
@@ -762,7 +766,7 @@ class Cocoon extends StatelessWidget {
         }
       };
     }
-    return () {};
+    return null;
   }
 
   // Get the value of the given field from the state if present

--- a/lib/cocoon.dart
+++ b/lib/cocoon.dart
@@ -7,6 +7,7 @@ library cocoon;
 import 'dart:convert';
 
 import 'package:cloud_firestore/cloud_firestore.dart';
+import 'package:cloud_functions/cloud_functions.dart';
 import 'package:flutter/material.dart';
 import 'package:http/http.dart';
 import 'package:icons_helper/icons_helper.dart';
@@ -735,7 +736,17 @@ class Cocoon extends StatelessWidget {
     Map<String, dynamic> json,
     GlobalKey<_CocoonState> stateKey,
   ) {
-    if (json.containsKey('destination')) {
+    if (json.containsKey('cloud_function')) {
+      return () async {
+        await CloudFunctions.instance
+            .getHttpsCallable(functionName: json['cloud_function'])
+            .call();
+        if (json.containsKey('destination')) {
+          Navigator.of(context).push(MaterialPageRoute(
+              builder: (context) => Cocoon(json['destination'])));
+        }
+      };
+    } else if (json.containsKey('destination')) {
       return () {
         Navigator.of(context).push(MaterialPageRoute(
           builder: (context) => Cocoon(json['destination']),

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -10,8 +10,9 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
-  http: ^0.12.0
-  cloud_firestore: ^0.11.0+2
+  http: any
+  cloud_firestore: any
+  cloud_functions: any
   icons_helper:
     git:
       url: git://github.com/sjmcdowall/icons_helper


### PR DESCRIPTION
## Description

Buttons can now specify a `cloud_function` property, which is the name of a Firebase Cloud Function which will be triggered when the button is pressed.

If the button also has a `destination` property, navigation to that destination will be delayed until after successful triggering of the cloud function.